### PR TITLE
Change the default history file location to follow ecosystem conventions

### DIFF
--- a/src/replmanager.ts
+++ b/src/replmanager.ts
@@ -8,9 +8,21 @@ import readline from 'rustybun';
 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 // Also ensures that the parent directory exists, so that the file can be created without issue.
 function repl_history_file_path(): string {
-    let dataFolder = process.env.BUN_INSTALL ?? (process.env.XDG_DATA_HOME) ?? path.join(os.homedir(), ".local/share")
+    const dataFolder = process.env.BUN_INSTALL ?? (process.env.XDG_DATA_HOME) ?? path.join(os.homedir(), ".local/share")
+    let history_path = path.join(dataFolder, "bun-repl/history");
     fs.mkdirSync(path.join(dataFolder, "bun-repl"), { recursive: true });
-    return path.join(dataFolder, "bun-repl/history")
+
+    if (!fs.existsSync(history_path)) {
+        const old_default_path = path.join(os.homedir(), ".bun_repl_history")
+        if (fs.existsSync(old_default_path)) {
+            console.info(`----------------
+Detected a bun-repl history file at the old default location: ${old_default_path}
+Moving to: ${history_path}
+----------------`);
+            fs.renameSync(old_default_path, history_path)
+        }
+    }
+    return history_path;
 }
 
 export default class REPLManager extends readline {

--- a/src/replmanager.ts
+++ b/src/replmanager.ts
@@ -1,13 +1,23 @@
 import $ from './colors';
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 import readline from 'rustybun';
+
+// Follows the XDG directory convention, accepting `BUN_INSTALL` as an override.
+// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+// Also ensures that the parent directory exists, so that the file can be created without issue.
+function repl_history_file_path(): string {
+    let dataFolder = process.env.BUN_INSTALL ?? (process.env.XDG_DATA_HOME) ?? path.join(os.homedir(), ".local/share")
+    fs.mkdirSync(path.join(dataFolder, "bun-repl"), { recursive: true });
+    return path.join(dataFolder, "bun-repl/history")
+}
 
 export default class REPLManager extends readline {
     constructor(prompt: string = '> ', historyPath?: string) {
         super();
         this.prompt = process.env.BUN_REPL_PROMPT ?? prompt;
-        historyPath ||= `${process.env.BUN_INSTALL ?? os.homedir()}/.bun_repl_history`;
+        historyPath ||= repl_history_file_path();
         this.#historyfd = fs.openSync(historyPath, 'a+');
         this.#historypath = historyPath;
 

--- a/src/replmanager.ts
+++ b/src/replmanager.ts
@@ -8,7 +8,7 @@ import readline from 'rustybun';
 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 // Also ensures that the parent directory exists, so that the file can be created without issue.
 function repl_history_file_path(): string {
-    const dataFolder = process.env.BUN_INSTALL ?? (process.env.XDG_DATA_HOME) ?? path.join(os.homedir(), ".local/share")
+    const dataFolder = process.env.BUN_INSTALL ?? process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local/share")
     let history_path = path.join(dataFolder, "bun-repl/history");
     fs.mkdirSync(path.join(dataFolder, "bun-repl"), { recursive: true });
 


### PR DESCRIPTION
Change the default history file location to `$XDG_DATA_HOME`.

`$BUN_INSTALL` remains an override, matching old behaviour. This means
that the history file location uses the following order of precedence,
using the first available env var (if one of them is defined):

- `$BUN_INSTALL/bun-repl/history`
- `$XDG_DATA_HOME/bun-repl/history`
- `~/.local/share/bun-repl/history`

The latter two paths matches the XDG directory convention, adopted
widely by projects (including `bun` itself) to organize application
folders instead of placing them directly in the home directory:
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

In addition, if the calculated history file path does not currently exist on disk but `~/.bun_repl_history` (the old default) exists, the latter is moved to the former location and the user is notified with a message. This allows transparent backwards compatibility for all users, without any action on their part.